### PR TITLE
Configure proper math formula support for GitHub Pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -15,7 +15,7 @@ email:
 twitter_username:
 
 # Set this to true to get LaTeX math equation support
-use_math:
+use_math: true
 
 # Add your Google Analytics ID here if you have one and want to use it
 google_analytics:

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -11,19 +11,20 @@
   {%- endif -%}
 
   {% if site.use_math %}
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.css" integrity="sha384-zB1R0rpPzHqg7Kpt0Aljp8JPLqbXI3bhnPWROx27a9N0Ll6ZP/+DiW/UqRcLbRjq" crossorigin="anonymous">
-    <script type="text/javascript" async src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-MML-AM_CHTML"> </script>
-    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.js" integrity="sha384-y23I5Q6l+B6vatafAwxRu/0oK/79VlbSz7Q9aiSZUvyWYIYsd+qj+o24G5ZU2zJz" crossorigin="anonymous"></script>
-    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/contrib/auto-render.min.js" integrity="sha384-kWPLUVMOks5AQFrykwIup5lo0m3iMkkHrD0uJ4H5cjeGihAutqP0yW0J6dpFiVkI" crossorigin="anonymous"></script>
+    <!-- KaTeX for fast math rendering -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.8/dist/katex.min.css" integrity="sha384-GvrOXuhMATgEsSwCs4smul74iXGOixntILdUW9XmUC6+HX0sLNAK3q71HotJqlAn" crossorigin="anonymous">
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.8/dist/katex.min.js" integrity="sha384-cpW21h6RZv/phavutF+AuVYrr+dA8xD9zs6FwLpaCct6O9ctzYFfFr4dgmgccOTx" crossorigin="anonymous"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.8/dist/contrib/auto-render.min.js" integrity="sha384-+VBxd3r6XgURycqtZ117nYw44OOcIax56Z4dCRWbxyPt0Koah1uHoK0o4+/RRE05" crossorigin="anonymous"></script>
     <script>
       document.addEventListener("DOMContentLoaded", function() {
-        renderMathInElement( document.body, {
+        renderMathInElement(document.body, {
           delimiters: [
             {left: "$$", right: "$$", display: true},
-            {left: "[%", right: "%]", display: true},
             {left: "$", right: "$", display: false}
-          ]}
-        );
+          ],
+          throwOnError: false,
+          strict: false
+        });
       });
     </script>
   {% endif %}


### PR DESCRIPTION
## Summary
Fix and improve math formula rendering on GitHub Pages by configuring proper KaTeX support and removing conflicting configurations.

## Issues Fixed
### Math Support Not Working
- **Problem**: `use_math` was not enabled in `_config.yml`
- **Solution**: Set `use_math: true` to activate math rendering

### Conflicting Math Engines
- **Problem**: Both MathJax and KaTeX were loaded simultaneously causing conflicts
- **Solution**: Use KaTeX-only for better performance and reliability

### Outdated Dependencies
- **Problem**: Using deprecated MathJax CDN and old KaTeX version (0.11.1)
- **Solution**: Update to latest KaTeX v0.16.8 with current CDN

### Complex Delimiter Configuration
- **Problem**: Mixed delimiter support causing rendering issues
- **Solution**: Simplified to standard `$$` (display) and `$` (inline) math

## Technical Changes
- ✅ **Enable math support**: `use_math: true` in `_config.yml`
- ✅ **Modern KaTeX v0.16.8**: Latest version with security updates
- ✅ **Remove MathJax**: Eliminate conflicting math engine
- ✅ **Clean delimiters**: Support `$$` and `$` syntax
- ✅ **Error handling**: `throwOnError: false` for robustness

## Benefits
- 🚀 **Faster rendering**: KaTeX is significantly faster than MathJax
- 🔧 **Better compatibility**: Modern version works with latest browsers
- 🛡️ **Error resilience**: Won't break page if math formula has syntax errors
- 📱 **Mobile friendly**: Better rendering on mobile devices

## Testing
- [x] Verify math formulas render in blog posts
- [x] Test both inline `$...$` and display `$$...$$` math
- [x] Confirm no JavaScript errors in browser console
- [x] Validate Jekyll build succeeds

This configuration will properly render all math formulas in the LLM inference blog post and future posts.

🤖 Generated with [Claude Code](https://claude.ai/code)